### PR TITLE
fix: resolve multiselect campaign filter visibility issue

### DIFF
--- a/src/components/dashboard/DashboardFilters.tsx
+++ b/src/components/dashboard/DashboardFilters.tsx
@@ -102,12 +102,10 @@ export function DashboardFilters({
                     />
                     <span className="text-sm font-medium">All Campaigns</span>
                   </div>
-                  {campaigns.map((campaign) => (
+                  {filteredCampaigns.map((campaign) => (
                     <div
                       key={campaign.id}
-                      className={`flex items-center space-x-2 p-2 hover:bg-muted/50 rounded cursor-pointer ${
-                        campaignSearchQuery === '' || filteredCampaigns.includes(campaign) ? '' : 'hidden'
-                      }`}
+                      className="flex items-center space-x-2 p-2 hover:bg-muted/50 rounded cursor-pointer"
                       onClick={() => handleCampaignToggle(campaign.id)}
                     >
                       <Checkbox 


### PR DESCRIPTION
- Fixed issue where selecting campaigns would hide other unselected campaigns in dropdown
- Replaced conditional hiding logic with proper filtered campaigns mapping
- Now all campaigns remain visible and selectable in multiselect dropdown