### PR TITLE
feat: sort campaigns by Campaign Start date in descending order

### DIFF
--- a/src/components/dashboard/DashboardFilters.tsx
+++ b/src/components/dashboard/DashboardFilters.tsx
@@ -8,7 +8,12 @@ import { Input } from "@/components/ui/input";
 import { Filter, Search } from "lucide-react";
 
 interface DashboardFiltersProps {
-  campaigns: Array<{ id: string; name: string }>;
+  campaigns: Array<{ 
+    id: string; 
+    name: string; 
+    launched_at?: string | null;
+    created_at: string;
+  }>;
   selectedCampaigns: string[];
   onCampaignChange: (campaignIds: string[]) => void;
   onClearFilters: () => void;
@@ -24,9 +29,22 @@ export function DashboardFilters({
   const [campaignSearchQuery, setCampaignSearchQuery] = useState("");
   const [tempSelectedCampaigns, setTempSelectedCampaigns] = useState<string[]>(selectedCampaigns);
 
-  const filteredCampaigns = campaigns.filter(campaign =>
-    campaign.name.toLowerCase().includes(campaignSearchQuery.toLowerCase())
-  );
+  const filteredCampaigns = campaigns
+    .filter(campaign =>
+      campaign.name.toLowerCase().includes(campaignSearchQuery.toLowerCase())
+    )
+    .sort((a, b) => {
+      // Ensure campaigns are sorted by Campaign Start date (launched_at) in descending order
+      // Even after filtering, maintain the same sort order as the main campaigns list
+      const dateA = a.launched_at || a.created_at;
+      const dateB = b.launched_at || b.created_at;
+      
+      const timeA = new Date(dateA).getTime();
+      const timeB = new Date(dateB).getTime();
+      
+      // Descending order (latest first)
+      return timeB - timeA;
+    });
 
   const handleCampaignToggle = (campaignId: string) => {
     if (campaignId === 'all') {

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -145,7 +145,21 @@ export function useDashboardData() {
         };
       }) || [];
 
-      setCampaigns(processedCampaigns);
+      // Sort campaigns by Campaign Start date (launched_at) in descending order
+      // Latest campaigns appear first. If launched_at is null, use created_at as fallback
+      const sortedCampaigns = processedCampaigns.sort((a, b) => {
+        const dateA = a.launched_at || a.created_at;
+        const dateB = b.launched_at || b.created_at;
+        
+        // Convert to Date objects for comparison
+        const timeA = new Date(dateA).getTime();
+        const timeB = new Date(dateB).getTime();
+        
+        // Descending order (latest first)
+        return timeB - timeA;
+      });
+
+      setCampaigns(sortedCampaigns);
       setConversations((conversationsData || []).map(conv => ({
         ...conv,
         analysis: conv.analysis || {},

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -131,7 +131,12 @@ export default function Dashboard() {
 
           {/* Dashboard Filters */}
           <DashboardFilters
-            campaigns={campaigns.map(c => ({ id: c.id, name: c.name }))}
+            campaigns={campaigns.map(c => ({ 
+              id: c.id, 
+              name: c.name, 
+              launched_at: c.launched_at,
+              created_at: c.created_at 
+            }))}
             selectedCampaigns={selectedCampaigns}
             onCampaignChange={handleCampaignChange}
             onClearFilters={handleClearFilters}


### PR DESCRIPTION
- Modified useDashboardData hook to sort campaigns by launched_at/created_at in descending order
- Updated DashboardFilters component to maintain descending order in filter dropdown
- Enhanced Dashboard component to pass campaign date information to filters
- Latest campaigns now appear first in both campaign list and filter dropdown
- Prioritizes launched_at over created_at for Campaign Start sorting