### PR TITLE
feat: remove text labels from Play & Download buttons in Call Details

### DIFF
--- a/src/components/dashboard/CampaignDetails.tsx
+++ b/src/components/dashboard/CampaignDetails.tsx
@@ -374,19 +374,17 @@ export function CampaignDetails({
                           variant="outline"
                           size="sm"
                           onClick={() => playAudio(conversation.conversation_id)}
-                          className="gap-1"
+                          title="Play recording"
                         >
                           <Volume2 className="h-4 w-4" />
-                          Play
                         </Button>
                         <Button
                           variant="outline"
                           size="sm"
                           onClick={() => downloadCallRecording(conversation.conversation_id)}
-                          className="gap-1"
+                          title="Download recording"
                         >
                           <Download className="h-4 w-4" />
-                          Download
                         </Button>
                       </div>
                     </TableCell>


### PR DESCRIPTION
- Remove 'Play' and 'Download' text labels from Recording column buttons
- Keep only icons (Volume2 and Download) for cleaner, more compact UI
- Add title attributes for accessibility and hover tooltips
- Maintain full button functionality with improved visual design
- Provide better space utilization in the Call Details table

This addresses the requirement: 'Under Call Details, Play & Download - remove label text, just keep icons.'