### PR TITLE
feat: implement new campaign metrics calculation with dynamic pricing

### DIFF
--- a/src/components/dashboard/CampaignsList.tsx
+++ b/src/components/dashboard/CampaignsList.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Eye, Phone, Target, Clock, IndianRupee } from "lucide-react";
-import { formatCost } from "@/utils/currency";
+import { Eye, Phone, Target, Clock, IndianRupee, DollarSign } from "lucide-react";
+import { formatCurrency } from "@/utils/currency";
 import {
   Table,
   TableBody,
@@ -30,9 +30,10 @@ interface CampaignsListProps {
   campaigns: Campaign[];
   onViewDetails: (campaignId: string) => void;
   isLoading?: boolean;
+  userCurrency?: string;
 }
 
-export function CampaignsList({ campaigns, onViewDetails, isLoading }: CampaignsListProps) {
+export function CampaignsList({ campaigns, onViewDetails, isLoading, userCurrency = 'INR' }: CampaignsListProps) {
   const getStatusBadge = (status: string) => {
     const statusMap = {
       'Draft': { variant: 'secondary' as const, label: 'Draft', className: '' },
@@ -43,6 +44,17 @@ export function CampaignsList({ campaigns, onViewDetails, isLoading }: Campaigns
     
     const statusInfo = statusMap[status as keyof typeof statusMap] || { variant: 'secondary' as const, label: status, className: '' };
     return <Badge variant={statusInfo.variant} className={statusInfo.className}>{statusInfo.label}</Badge>;
+  };
+
+  const getCurrencyIcon = (currency: string) => {
+    switch (currency?.toLowerCase()) {
+      case 'inr':
+        return <IndianRupee className="h-4 w-4 text-muted-foreground" />;
+      case 'usd':
+        return <DollarSign className="h-4 w-4 text-muted-foreground" />;
+      default:
+        return <DollarSign className="h-4 w-4 text-muted-foreground" />;
+    }
   };
 
 
@@ -115,7 +127,7 @@ export function CampaignsList({ campaigns, onViewDetails, isLoading }: Campaigns
                 <TableHead className="text-center">Connected</TableHead>
                 <TableHead className="text-center">Success Rate</TableHead>
                 <TableHead className="text-right">Total Cost</TableHead>
-                <TableHead className="text-center">Duration</TableHead>
+                <TableHead className="text-center">Total Minutes</TableHead>
                 <TableHead className="text-center">Actions</TableHead>
               </TableRow>
             </TableHeader>
@@ -172,14 +184,14 @@ export function CampaignsList({ campaigns, onViewDetails, isLoading }: Campaigns
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <IndianRupee className="h-4 w-4 text-muted-foreground" />
-                      {formatCost(campaign.totalCost)}
+                      {getCurrencyIcon(userCurrency)}
+                      {formatCurrency(campaign.totalCost, userCurrency)}
                     </div>
                   </TableCell>
                   <TableCell className="text-center">
                     <div className="flex items-center justify-center gap-1">
                       <Clock className="h-4 w-4 text-muted-foreground" />
-                      {formatDuration(campaign.totalMinutes * 60)}
+                      {campaign.totalMinutes} min
                     </div>
                   </TableCell>
                   <TableCell className="text-center">

--- a/src/components/dashboard/DashboardMetrics.tsx
+++ b/src/components/dashboard/DashboardMetrics.tsx
@@ -1,6 +1,6 @@
 import { KPICard } from "./KPICard";
-import { Phone, Users, Target, Clock, IndianRupee } from "lucide-react";
-import { formatCost } from "@/utils/currency";
+import { Phone, Users, Target, Clock, IndianRupee, DollarSign } from "lucide-react";
+import { formatCurrency } from "@/utils/currency";
 
 interface MetricsData {
   totalCalls: number;
@@ -13,15 +13,19 @@ interface MetricsData {
 interface DashboardMetricsProps {
   metrics: MetricsData;
   isLoading?: boolean;
+  userCurrency?: string;
 }
 
-export function DashboardMetrics({ metrics, isLoading }: DashboardMetricsProps) {
-  const formatDuration = (seconds: number) => {
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) return `${minutes}m`;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-    return `${hours}h ${remainingMinutes}m`;
+export function DashboardMetrics({ metrics, isLoading, userCurrency = 'INR' }: DashboardMetricsProps) {
+  const getCurrencyIcon = (currency: string) => {
+    switch (currency?.toLowerCase()) {
+      case 'inr':
+        return IndianRupee;
+      case 'usd':
+        return DollarSign;
+      default:
+        return DollarSign;
+    }
   };
 
 
@@ -56,13 +60,13 @@ export function DashboardMetrics({ metrics, isLoading }: DashboardMetricsProps) 
       />
       <KPICard
         title="Total Minutes"
-        value={formatDuration(metrics.totalMinutes * 60)}
+        value={`${metrics.totalMinutes} min`}
         icon={Clock}
       />
       <KPICard
         title="Total Cost"
-        value={formatCost(metrics.totalCost)}
-        icon={IndianRupee}
+        value={formatCurrency(metrics.totalCost, userCurrency)}
+        icon={getCurrencyIcon(userCurrency)}
       />
     </div>
   );

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import { DateRange } from "react-day-picker";
+import { useProfile } from "@/hooks/useProfile";
 
 interface MetricsData {
   totalCalls: number;
@@ -38,6 +39,13 @@ interface ConversationDetail {
   conversation_id: string;
 }
 
+// Helper function to calculate minutes based on the new billing logic
+const calculateBillingMinutes = (durationSeconds: number): number => {
+  if (durationSeconds <= 0) return 0;
+  if (durationSeconds <= 60) return 1;
+  return Math.ceil(durationSeconds / 60);
+};
+
 export function useDashboardData() {
   const [metrics, setMetrics] = useState<MetricsData>({
     totalCalls: 0,
@@ -50,6 +58,7 @@ export function useDashboardData() {
   const [conversations, setConversations] = useState<ConversationDetail[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
+  const { profile } = useProfile();
 
   const fetchDashboardData = async (selectedCampaigns?: string[]) => {
     try {
@@ -111,8 +120,15 @@ export function useDashboardData() {
       const totalCalls = conversationsData?.length || 0;
       const connectedCalls = conversationsData?.filter(c => c.call_successful === 'success').length || 0;
       const successRate = totalCalls > 0 ? (connectedCalls / totalCalls) * 100 : 0;
-      const totalMinutes = conversationsData?.reduce((sum, c) => sum + (c.call_duration_secs / 60), 0) || 0;
-      const totalCost = conversationsData?.reduce((sum, c) => sum + (c.total_cost || 0), 0) || 0;
+      
+      // Calculate total minutes using new billing logic
+      const totalMinutes = conversationsData?.reduce((sum, c) => {
+        return sum + calculateBillingMinutes(c.call_duration_secs || 0);
+      }, 0) || 0;
+      
+      // Calculate total cost based on user's currency and call rate from profile
+      const callRate = profile?.call_rate || 0;
+      const totalCost = totalMinutes * callRate;
 
       setMetrics({
         totalCalls,
@@ -128,8 +144,15 @@ export function useDashboardData() {
         
         const campaignConnected = campaignCalls.filter((c: any) => c.call_successful === 'success').length;
         const campaignSuccessRate = campaignCalls.length > 0 ? (campaignConnected / campaignCalls.length) * 100 : 0;
-        const campaignMinutes = campaignCalls.reduce((sum: number, c: any) => sum + (c.call_duration_secs / 60), 0);
-        const campaignCost = campaignCalls.reduce((sum: number, c: any) => sum + (c.total_cost || 0), 0);
+        
+        // Calculate total minutes using new billing logic: <=60sec = 1min, >60&<=120 = 2min, etc.
+        const campaignMinutes = campaignCalls.reduce((sum: number, c: any) => {
+          return sum + calculateBillingMinutes(c.call_duration_secs || 0);
+        }, 0);
+        
+        // Calculate total cost based on user's currency and call rate from profile
+        const callRate = profile?.call_rate || 0;
+        const campaignCost = campaignMinutes * callRate;
 
         return {
           id: campaign.id,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -8,6 +8,9 @@ interface Profile {
   full_name: string | null;
   company: string | null;
   phone: string | null;
+  currency: string;
+  call_rate: number;
+  available_minutes: number;
 }
 
 export function useProfile() {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -143,13 +143,14 @@ export default function Dashboard() {
           />
 
           {/* Dashboard Metrics */}
-          <DashboardMetrics metrics={metrics} isLoading={isLoading} />
+          <DashboardMetrics metrics={metrics} isLoading={isLoading} userCurrency={profile?.currency || 'INR'} />
 
           {/* Campaigns List */}
           <CampaignsList
             campaigns={campaigns}
             onViewDetails={handleViewDetails}
             isLoading={isLoading}
+            userCurrency={profile?.currency || 'INR'}
           />
         </div>
       )}


### PR DESCRIPTION
## Campaign List Updates
- Rename 'Duration' column to 'Total Minutes'
- Implement new minute billing logic: <=60sec = 1min, >60&<=120sec = 2min, etc.
- Display total minutes as sum of all calls using ceiling-based calculation

## Dynamic Cost Calculation
- Calculate Total Cost using user's currency and call_rate from profiles table
- Formula: Total Cost = Total Minutes * call_rate (using user's currency)
- Support multiple currencies (INR, USD) with appropriate icons

## Profile Integration
- Extended Profile interface to include currency, call_rate, available_minutes
- Updated useDashboardData hook to fetch and use profile data for calculations
- Dynamic currency display based on user's profile settings

## UI Improvements
- Updated DashboardMetrics to show minutes instead of formatted duration
- Dynamic currency icons (₹ for INR, $ for USD)
- Consistent currency formatting across campaign list and metrics

## Calculation Example (as per requirements)
Call 1: 0:19 (19 sec) = 1 minute
Call 2: 1:35 (95 sec) = 2 minutes
Call 3: 2:00 (120 sec) = 2 minutes
Total Minutes = 5 minutes ✅

This addresses all requirements:
1. 'Duration' renamed to 'Total Minutes'
2. New minute calculation logic implemented
3. Total Cost = {currency} Total Minutes * {call_rate} from profiles table