### PR TITLE
feat: remove 'View' text labels from Data Collection & Transcript but…

### DIFF
--- a/src/components/dashboard/CampaignDetails.tsx
+++ b/src/components/dashboard/CampaignDetails.tsx
@@ -457,10 +457,9 @@ export function CampaignDetails({
                         variant="outline"
                         size="sm"
                         onClick={() => setSelectedDataCollection(conversation)}
-                        className="gap-1"
+                        title="View data collection"
                       >
                         <FileText className="h-4 w-4" />
-                        View
                       </Button>
                     </TableCell>
                     <TableCell>
@@ -471,10 +470,9 @@ export function CampaignDetails({
                           setSelectedTranscript(conversation);
                           fetchTranscript(conversation.conversation_id);
                         }}
-                        className="gap-1"
+                        title="View transcript"
                       >
                         <MessageSquare className="h-4 w-4" />
-                        View
                       </Button>
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
…tons

## UI Improvement: Icon-Only Buttons
- Removed 'View' text labels from Data Collection column button
- Removed 'View' text labels from Transcript column button
- Kept only icons (FileText and MessageSquare) for cleaner UI
- Added title attributes for accessibility and hover tooltips

## Changes Made
- **Data Collection Button**: Now shows only FileText icon with 'View data collection' tooltip
- **Transcript Button**: Now shows only MessageSquare icon with 'View transcript' tooltip
- **Accessibility**: Added proper title attributes for screen readers and hover help
- **Clean UI**: More compact and professional appearance in Call Details table

## Technical Changes
- Removed 'className="gap-1"' from both buttons (no longer needed without text)
- Replaced with 'title' attributes for accessibility
- Maintained all existing functionality and click handlers
- Consistent styling with other icon-only buttons in the application

## Benefits
✅ **Cleaner Interface**: More compact Call Details table columns ✅ **Consistent Design**: Matches icon-only pattern used elsewhere ✅ **Space Efficient**: Better utilization of table space ✅ **Professional Look**: Modern, minimalist button design ✅ **Accessibility**: Proper tooltips for user guidance

This addresses the requirement: 'Under Call Details page for the columns - Data Collection & Transcript - remove View label text, just keep icons.'