### PR TITLE
Fix elevenlabs field names

### DIFF
--- a/supabase/functions/launch-campaign/index.ts
+++ b/supabase/functions/launch-campaign/index.ts
@@ -39,52 +39,60 @@ serve(async (req) => {
     );
 
     console.log('Launching campaign with data:', {
-      call_name: callName,
+      batch_name: callName,
       agent_id: agentId,
-      agent_phone_number_id: phoneNumberId,
-      scheduled_time_unix: scheduledTimeUnix,
+      phone_number_id: phoneNumberId,
+      scheduled_time: scheduledTimeUnix ? new Date(scheduledTimeUnix * 1000).toISOString() : null,
       recipients: recipients,
       contactsWithFields: contactsWithFields
     });
 
-    // Prepare ElevenLabs API payload
-    const elevenlabsPayload = {
-      call_name: callName,
+    // Prepare ElevenLabs API payload according to the official documentation
+    const elevenlabsPayload: any = {
+      batch_name: callName, // Use batch_name as per API spec
       agent_id: agentId,
-      agent_phone_number_id: phoneNumberId,
-      scheduled_time_unix: scheduledTimeUnix,
+      phone_number_id: phoneNumberId, // Remove 'agent_' prefix as per API spec
       recipients: contactsWithFields ? contactsWithFields.map((contact: any) => {
         // Extract dynamic variables from contact's additional_fields
         const dynamicVariables: any = {};
         
-        // Add name if available
+        // Add name if available (exclude phone_number from dynamic variables)
         if (contact.name) {
-          dynamicVariables.name = contact.name;
+          dynamicVariables.user_name = contact.name; // Use descriptive key
         }
         
         // Add all fields from additional_fields if available
+        // Any field other than phone_number should be a dynamic variable
         if (contact.additional_fields && typeof contact.additional_fields === 'object') {
           Object.keys(contact.additional_fields).forEach(key => {
-            if (contact.additional_fields[key] !== null && contact.additional_fields[key] !== undefined && contact.additional_fields[key] !== '') {
+            // Skip phone number and empty values
+            if (key !== 'phone_number' && key !== 'phone' && 
+                contact.additional_fields[key] !== null && 
+                contact.additional_fields[key] !== undefined && 
+                contact.additional_fields[key] !== '') {
               dynamicVariables[key] = contact.additional_fields[key];
             }
           });
         }
         
-        // Only include conversation_initiation_client_data if there are dynamic variables
+        // Build recipient according to correct API structure
         const recipient: any = {
           phone_number: contact.phone
         };
         
+        // Add dynamic_variables directly (not wrapped in conversation_initiation_client_data)
         if (Object.keys(dynamicVariables).length > 0) {
-          recipient.conversation_initiation_client_data = {
-            dynamic_variables: dynamicVariables
-          };
+          recipient.dynamic_variables = dynamicVariables;
         }
         
         return recipient;
       }) : recipients.map((phone: string) => ({ phone_number: phone }))
     };
+
+    // Add scheduled_time in ISO format if provided (convert from Unix timestamp)
+    if (scheduledTimeUnix && scheduledTimeUnix > 0) {
+      elevenlabsPayload.scheduled_time = new Date(scheduledTimeUnix * 1000).toISOString();
+    }
 
     // Log the exact payload being sent to ElevenLabs
     console.log('ElevenLabs API payload:', JSON.stringify(elevenlabsPayload, null, 2));

--- a/supabase/functions/launch-campaign/index.ts
+++ b/supabase/functions/launch-campaign/index.ts
@@ -39,19 +39,19 @@ serve(async (req) => {
     );
 
     console.log('Launching campaign with data:', {
-      batch_name: callName,
+      call_name: callName,
       agent_id: agentId,
-      phone_number_id: phoneNumberId,
-      scheduled_time: scheduledTimeUnix ? new Date(scheduledTimeUnix * 1000).toISOString() : null,
+      agent_phone_number_id: phoneNumberId,
+      scheduled_time_unix: scheduledTimeUnix,
       recipients: recipients,
       contactsWithFields: contactsWithFields
     });
 
     // Prepare ElevenLabs API payload according to the official documentation
     const elevenlabsPayload: any = {
-      batch_name: callName, // Use batch_name as per API spec
+      call_name: callName, // Use call_name as per API spec
       agent_id: agentId,
-      phone_number_id: phoneNumberId, // Remove 'agent_' prefix as per API spec
+      agent_phone_number_id: phoneNumberId, // Use agent_phone_number_id as per API spec
       recipients: contactsWithFields ? contactsWithFields.map((contact: any) => {
         // Extract dynamic variables from contact's additional_fields
         const dynamicVariables: any = {};
@@ -89,9 +89,9 @@ serve(async (req) => {
       }) : recipients.map((phone: string) => ({ phone_number: phone }))
     };
 
-    // Add scheduled_time in ISO format if provided (convert from Unix timestamp)
+    // Add scheduled_time_unix if provided (use Unix timestamp format)
     if (scheduledTimeUnix && scheduledTimeUnix > 0) {
-      elevenlabsPayload.scheduled_time = new Date(scheduledTimeUnix * 1000).toISOString();
+      elevenlabsPayload.scheduled_time_unix = scheduledTimeUnix;
     }
 
     // Log the exact payload being sent to ElevenLabs


### PR DESCRIPTION
Title: Fix ElevenLabs API field names
Description: Field name corrections to match official ElevenLabs API specification while maintaining dynamic variables improvements

Dynamic Variables Structure Fix:
Before
{
  "phone_number": "+1234567890",
  "conversation_initiation_client_data": {
    "dynamic_variables": {
      "user_name": "John Doe"
    }
  }
}

After
{
  "phone_number": "+1234567890", 
  "dynamic_variables": {
    "user_name": "John Doe",
    "account_type": "premium",
    "balance": 1500.00
  }
}
