### PR TITLE
refactor: Remove name field from contacts, use additional_fields only

### DIFF
--- a/src/components/dashboard/CampaignDetails.tsx
+++ b/src/components/dashboard/CampaignDetails.tsx
@@ -22,7 +22,7 @@ import { useToast } from "@/hooks/use-toast";
 interface ConversationDetail {
   id: string;
   phone_number: string;
-  contact_name: string;
+  contact_name?: string;
   call_successful: string;
   call_duration_secs: number;
   start_time_unix: number;
@@ -162,7 +162,7 @@ export function CampaignDetails({
 
       return {
         'Phone Number': conversation.phone_number || 'N/A',
-        'Name': conversation.contact_name || 'Unknown',
+        'Name': conversation.dynamic_variables?.name || conversation.dynamic_variables?.user_name || conversation.additional_fields?.name || 'N/A',
         'Call Status': conversation.call_successful || 'Unknown',
         'Date': formatDateOnly(conversation.start_time_unix),
         'Start Time': formatTimeOnly(conversation.start_time_unix),

--- a/src/pages/RunCampaign.tsx
+++ b/src/pages/RunCampaign.tsx
@@ -161,10 +161,9 @@ export default function RunCampaign() {
         .insert(
           parsedContacts.map(contact => ({
             user_id: user.id,
-            name: contact.name,
             phone: contact.phone,
             additional_fields: Object.fromEntries(
-              Object.entries(contact).filter(([key]) => !['id', 'name', 'phone'].includes(key))
+              Object.entries(contact).filter(([key]) => !['id', 'phone'].includes(key))
             ),
           }))
         );
@@ -257,7 +256,6 @@ export default function RunCampaign() {
       // Prepare contacts with all fields for dynamic variables (excluding phone number)
       const contactsWithFields = contacts.map(contact => ({
         phone: contact.phone,
-        name: contact.name,
         ...contact // This includes all additional fields from CSV or manual entry
       }));
 

--- a/supabase/functions/launch-campaign/index.ts
+++ b/supabase/functions/launch-campaign/index.ts
@@ -102,9 +102,11 @@ serve(async (req) => {
           phone_number: contact.phone
         };
         
-        // Add dynamic_variables directly (not wrapped in conversation_initiation_client_data)
+        // Add dynamic_variables wrapped in conversation_initiation_client_data as per API spec
         if (Object.keys(dynamicVariables).length > 0) {
-          recipient.dynamic_variables = dynamicVariables;
+          recipient.conversation_initiation_client_data = {
+            dynamic_variables: dynamicVariables
+          };
           // Log extracted dynamic variables for debugging
           console.log(`Dynamic variables for ${contact.phone}:`, JSON.stringify(dynamicVariables, null, 2));
         } else {

--- a/supabase/migrations/20250920_remove_name_column_from_contacts.sql
+++ b/supabase/migrations/20250920_remove_name_column_from_contacts.sql
@@ -1,0 +1,18 @@
+-- Remove name column from contacts table
+-- All name data should be stored in additional_fields JSON column
+
+-- First, migrate existing name data to additional_fields
+UPDATE contacts 
+SET additional_fields = COALESCE(additional_fields, '{}'::jsonb) || 
+  CASE 
+    WHEN name IS NOT NULL AND name != '' 
+    THEN jsonb_build_object('name', name)
+    ELSE '{}'::jsonb
+  END
+WHERE name IS NOT NULL AND name != '';
+
+-- Drop the name column
+ALTER TABLE contacts DROP COLUMN IF EXISTS name;
+
+-- Add comment to document the change
+COMMENT ON TABLE contacts IS 'Contacts table - name and other custom fields stored in additional_fields JSON column';


### PR DESCRIPTION
BREAKING CHANGES:
- Remove Name field from 'Enter Contacts Manually' modal
- Phone Number is now the only mandatory field
- All custom fields (including name) stored in additional_fields JSON
- Database migration to remove name column from contacts table
- Fix ElevenLabs API structure to use conversation_initiation_client_data wrapper

Changes Made:
- Updated ContactsModal to remove Name field, keep only Phone Number as required
- Created database migration to move existing names to additional_fields
- Updated CSV upload logic to store all fields in additional_fields
- Fixed ElevenLabs API payload structure per official specification
- Updated CampaignDetails to get names from dynamic_variables/additional_fields
- All contact data now properly flows through additional_fields JSON column

API Structure Now Matches ElevenLabs Specification: {
  "recipients": [{
    "phone_number": "918882851490",
    "conversation_initiation_client_data": {
      "dynamic_variables": {
        "person_name": "abhishek agarwal",
        "person_age": "34"
      }
    }
  }]
}