### PR TITLE
feat: Sync campaign status with batch_calls status

### DIFF
--- a/supabase/functions/get-batch-status/index.ts
+++ b/supabase/functions/get-batch-status/index.ts
@@ -2,6 +2,65 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+// Helper function to update campaign status based on batch status
+async function updateCampaignStatus(supabase: any, batchId: string, batchStatus: string) {
+  try {
+    // First, get the campaign_id associated with this batch
+    const { data: batchCallData, error: fetchError } = await supabase
+      .from('batch_calls')
+      .select('campaign_id')
+      .eq('batch_id', batchId)
+      .single();
+
+    if (fetchError) {
+      console.error('Error fetching batch call data:', fetchError);
+      return;
+    }
+
+    if (!batchCallData?.campaign_id) {
+      console.log('No campaign_id found for batch:', batchId);
+      return;
+    }
+
+    let campaignStatus = null;
+    
+    // Map batch status to campaign status
+    switch (batchStatus?.toLowerCase()) {
+      case 'completed':
+      case 'successful':
+      case 'success':
+        campaignStatus = 'Completed';
+        break;
+      case 'failed':
+      case 'error':
+      case 'cancelled':
+        campaignStatus = 'Failed';
+        break;
+      // Don't update campaign status for other statuses (pending, running, etc.)
+    }
+
+    if (campaignStatus) {
+      console.log(`Updating campaign ${batchCallData.campaign_id} status to: ${campaignStatus}`);
+      
+      const { error: campaignError } = await supabase
+        .from('campaigns')
+        .update({
+          status: campaignStatus,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', batchCallData.campaign_id);
+
+      if (campaignError) {
+        console.error('Error updating campaign status:', campaignError);
+      } else {
+        console.log(`Successfully updated campaign status to: ${campaignStatus}`);
+      }
+    }
+  } catch (error) {
+    console.error('Error in updateCampaignStatus:', error);
+  }
+}
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -58,6 +117,9 @@ serve(async (req) => {
     if (error) {
       console.error('Error updating batch status:', error);
     }
+
+    // Update corresponding campaign status
+    await updateCampaignStatus(supabase, batchId, batchData.status);
 
     return new Response(JSON.stringify(batchData), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/poll-batch-status/index.ts
+++ b/supabase/functions/poll-batch-status/index.ts
@@ -2,6 +2,66 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+// Helper function to update campaign status based on batch status
+async function updateCampaignStatus(supabase: any, batchId: string, batchStatus: string, userId: string) {
+  try {
+    // First, get the campaign_id associated with this batch
+    const { data: batchCallData, error: fetchError } = await supabase
+      .from('batch_calls')
+      .select('campaign_id')
+      .eq('batch_id', batchId)
+      .eq('user_id', userId)
+      .single();
+
+    if (fetchError) {
+      console.error('Error fetching batch call data:', fetchError);
+      return;
+    }
+
+    if (!batchCallData?.campaign_id) {
+      console.log('No campaign_id found for batch:', batchId);
+      return;
+    }
+
+    let campaignStatus = null;
+    
+    // Map batch status to campaign status
+    switch (batchStatus?.toLowerCase()) {
+      case 'completed':
+      case 'successful':
+      case 'success':
+        campaignStatus = 'Completed';
+        break;
+      case 'failed':
+      case 'error':
+      case 'cancelled':
+        campaignStatus = 'Failed';
+        break;
+      // Don't update campaign status for other statuses (pending, running, etc.)
+    }
+
+    if (campaignStatus) {
+      console.log(`Updating campaign ${batchCallData.campaign_id} status to: ${campaignStatus}`);
+      
+      const { error: campaignError } = await supabase
+        .from('campaigns')
+        .update({
+          status: campaignStatus,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', batchCallData.campaign_id);
+
+      if (campaignError) {
+        console.error('Error updating campaign status:', campaignError);
+      } else {
+        console.log(`Successfully updated campaign status to: ${campaignStatus}`);
+      }
+    }
+  } catch (error) {
+    console.error('Error in updateCampaignStatus:', error);
+  }
+}
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -73,6 +133,9 @@ serve(async (req) => {
         if (batchUpdateError) {
           console.error('Error updating batch status:', batchUpdateError);
         }
+
+        // Update corresponding campaign status
+        await updateCampaignStatus(supabase, batchId, batchData.status, userId);
 
         // Save recipients data if available
         if (batchData.recipients && Array.isArray(batchData.recipients)) {


### PR DESCRIPTION
- Update get-batch-status function to sync campaign status based on batch status
- Update poll-batch-status function to sync campaign status during polling
- Update eleven-labs-webhook function to sync campaign status on webhook updates
- Add helper function for consistent campaign status mapping across all functions

Campaign Status Mapping:
- Batch 'completed'/'successful'/'success' → Campaign 'Completed'
- Batch 'failed'/'error'/'cancelled' → Campaign 'Failed'
- Other statuses (pending/running) → No campaign status change

Functions Updated:
- supabase/functions/get-batch-status/index.ts
- supabase/functions/poll-batch-status/index.ts
- supabase/functions/eleven-labs-webhook/index.ts

This ensures campaigns table status column stays synchronized with the corresponding batch_calls status for proper dashboard display.