### PR TITLE
fix: Correct Call Status column mapping to use conversations.status

### DIFF
--- a/src/components/dashboard/CampaignDetails.tsx
+++ b/src/components/dashboard/CampaignDetails.tsx
@@ -23,6 +23,7 @@ interface ConversationDetail {
   id: string;
   phone_number: string;
   contact_name?: string;
+  status: string; // Conversation status (completed, failed, in_progress, etc.)
   call_successful: string;
   call_duration_secs: number;
   start_time_unix: number;
@@ -163,7 +164,7 @@ export function CampaignDetails({
       return {
         'Phone Number': conversation.phone_number || 'N/A',
         'Name': conversation.dynamic_variables?.name || conversation.dynamic_variables?.user_name || conversation.additional_fields?.name || 'N/A',
-        'Call Status': conversation.call_successful || 'Unknown',
+        'Call Status': conversation.status || 'Unknown',
         'Date': formatDateOnly(conversation.start_time_unix),
         'Start Time': formatTimeOnly(conversation.start_time_unix),
         'Duration': formatDuration(conversation.call_duration_secs),
@@ -396,7 +397,7 @@ export function CampaignDetails({
                       )}
                     </TableCell>
                     <TableCell>
-                      {getCallStatusBadge(conversation.call_successful)}
+                      {getCallStatusBadge(conversation.status)}
                     </TableCell>
                     <TableCell>
                       {formatDateOnly(conversation.start_time_unix)}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -29,6 +29,7 @@ interface ConversationDetail {
   id: string;
   phone_number: string;
   contact_name: string;
+  status: string; // Conversation status (completed, failed, in_progress, etc.)
   call_successful: string;
   call_duration_secs: number;
   start_time_unix: number;


### PR DESCRIPTION
- Fix Call Status column in CampaignDetails to use conversation.status instead of call_successful
- Update ConversationDetail interfaces to include status field
- Fix Excel export to use correct status field for Call Status column
- Maintain call_successful field usage for metrics calculation (success rate)

Field Purpose Clarification:
- status: Overall conversation status (completed, failed, in_progress, etc.) → Call Status column
- call_successful: Specific call outcome (success, no_answer, busy, etc.) → Metrics calculation

Components Updated:
- src/components/dashboard/CampaignDetails.tsx
- src/hooks/useDashboardData.ts

This ensures Call Status column shows the correct conversation status instead of being incorrectly mapped to evaluation data.